### PR TITLE
fix: 親コンポーネントから子コンポーネントを切り分け

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import QuizApp from './quiz-app';
+import QuizApp from './QuizIndex';
 
 function App() {
   return (

--- a/src/QuizIndex.jsx
+++ b/src/QuizIndex.jsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { TopPage } from "./components/TopPage"
+import { QuizSelectionPage } from "./components/QuizSelectionPage"
 
 const quizData = [
   {
@@ -121,7 +123,7 @@ const QuizApp = () => {
     }, 1000)
   }
 
-  const shuffleAnswers = () => {
+  const shuffleAnswers = () => {   // 正解と間違いを
     const currentQuizData = quizData[currentQuestion]
     const allAnswers = [currentQuizData.correctAnswer, ...currentQuizData.incorrectAnswers]
     setShuffledAnswers(allAnswers.sort(() => Math.random() - 0.5))
@@ -176,74 +178,17 @@ const QuizApp = () => {
       <h1 style={{ color: "red", backgroundColor: "lightyellow", marginBottom: "15px" }}>高速ご挨拶クイズ</h1>
 
       {gameState === "start" && (
-        <div>
-          <h3 style={{ color: "orange", marginBottom: "20px" }}>全人類の基本をクリアせよ！</h3>
-          <div style={{ marginBottom: "30px" }}>
-            <img src="/images/ご挨拶.png" alt="スタート画面" style={{ width: "auto", height: "250px" }} />
-          </div>
-          <button
-            onClick={startGame}
-            style={{
-              ...commonButtonStyle,
-              backgroundColor: "violet",
-            }}
-            onMouseOver={(e) => {
-              e.currentTarget.style.backgroundColor = "orange"
-              e.currentTarget.style.boxShadow = "none"
-            }}
-            onMouseOut={(e) => {
-              e.currentTarget.style.backgroundColor = "violet"
-              e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
-            }}
-          >
-            みんなに好かれにいく
-          </button>
-        </div>
+        <TopPage
+          // 名前 = {バリュー(値)}
+          handleClick={startGame}
+        />
       )}
 
-      {gameState === "playing" && (
-        <div>
-          <div
-            style={{
-              fontSize: "30px",
-              fontWeight: "bold",
-              color: timeLeft <= 2 ? "red" : "orange",
-            }}
-          >
-            {timeLeft} 秒以内に
-          </div>
-          <h3 style={{ color: "orange" }}>{`ご挨拶しよう！`}</h3>
 
-          <div style={{ marginBottom: "20px" }}>
-            <img
-              src={quizData[currentQuestion].image || "/placeholder.svg"}
-              alt="人物"
-              style={{ width: "auto", height: "250px" }}
-            />
-          </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px", margin: "0 auto" }}>
-            {shuffledAnswers.map((answer, index) => (
-              <button
-                key={index}
-                onClick={() => handleAnswer(answer)}
-                style={{
-                  ...commonButtonStyle,
-                  backgroundColor: "#00BBFF", // ほどよい青
-                }}
-                onMouseOver={(e) => {
-                  e.currentTarget.style.backgroundColor = "orange"
-                  e.currentTarget.style.boxShadow = "none"
-                }}
-                onMouseOut={(e) => {
-                  e.currentTarget.style.backgroundColor = "#00BBFF"  // ほどよい青
-                  e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
-                }}
-              >
-                {answer}
-              </button>
-            ))}
-          </div>
-        </div>
+      {gameState === "playing" && (
+        <QuizSelectionPage
+          selectedAnswer={handleAnswer}
+        />
       )}
 
       {gameState === "answered" && (
@@ -281,15 +226,15 @@ const QuizApp = () => {
                 left: "50%",
                 transform: "translate(-50%, -50%)",
                 backgroundColor: isTimeUp
-                  ? "rgba(130, 130, 130, 0.9)" // グレー
+                  ? "rgba(130, 130, 130, 0.9)"   // グレー
                   : isCorrect
-                    ? "rgba(0, 255, 0, 0.9)"   // 緑
-                    : "rgba(255, 0, 0, 0.9)",  // 赤
-                color: "white",
-                padding: "20px",
+                    ? "rgba(0, 255, 0, 0.9)"     // 緑
+                    : "rgba(255, 0, 0, 0.9)",    // 赤
+                color:        "white",
+                padding:      "20px",
                 borderRadius: "5px",
-                fontSize: "30px",
-                fontWeight: "bold",
+                fontSize:     "30px",
+                fontWeight:   "bold",
               }}
             >
               {isTimeUp ? "時間切れ⏰" : isCorrect ? "正しい😊" : "違うで😠"}

--- a/src/QuizIndex.jsx
+++ b/src/QuizIndex.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { TopPage } from "./components/TopPage"
 import { QuizSelectionPage } from "./components/QuizSelectionPage"
+import { AnsweredPage } from "./components/AnsweredPage"
 
 const quizData = [
   {
@@ -49,10 +50,10 @@ const QuizApp = () => {
   const [gameState, setGameState] = useState("start")     // start, playing, answered, finished
   const [shuffledAnswers, setShuffledAnswers] = useState([])
   const [selectedAnswer, setSelectedAnswer] = useState(null)
-  const [isCorrect, setIsCorrect] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
   const [timeCount, setTimeCount] = useState(3)             // 出題タイマー
   const [isTimeUp, setIsTimeUp] = useState(false)         // タイムアップフラグ
-  const [resultTimeCount, setResultTimeCount] = useState(3) // 結果表示の3秒カウントダウン
+  const [nextTimeCount, setNextTimeCount] = useState(2) // 結果表示の2秒カウントダウン
 
   useEffect(() => {
     if (justQuestion < quizData.length) {
@@ -73,13 +74,13 @@ const QuizApp = () => {
             // タイムアップ処理
             setIsTimeUp(true)
             setGameState("answered")
-            setResultTimeCount(3) // 結果表示の3秒カウントダウンをセット
+            setNextTimeCount(2) // 結果表示の2秒カウントダウンをセット
 
             // 結果表示用のカウントダウンタイマーを開始
-            const resultTimer = setInterval(() => {
-              setResultTimeCount((prevTime) => {
+            const nextTimer = setInterval(() => {
+              setNextTimeCount((prevTime) => {
                 if (prevTime <= 1) {
-                  clearInterval(resultTimer)
+                  clearInterval(nextTimer)
                   nextQuestion()
                   return 0
                 }
@@ -102,19 +103,19 @@ const QuizApp = () => {
   const handleAnswer = (selectedAnswer) => {
     setSelectedAnswer(selectedAnswer)
     const correct = selectedAnswer === quizData[justQuestion].justAnswer
-    setIsCorrect(correct)
+    setIsSuccess(correct)
     if (correct) {
       setScore(score + 1)
     }
     setGameState("answered")
     setIsTimeUp(false)       // タイムアップをリセット
-    setResultTimeCount(3)     // 結果表示の3秒カウントダウンをセット
+    setNextTimeCount(2)     // 結果表示の2秒カウントダウンをセット
 
     // 結果表示用のカウントダウンタイマーを開始
-    const resultTimer = setInterval(() => {
-      setResultTimeCount((prevTime) => {
+    const nextTimer = setInterval(() => {
+      setNextTimeCount((prevTime) => {
         if (prevTime <= 1) {
-          clearInterval(resultTimer)
+          clearInterval(nextTimer)
           nextQuestion()
           return 0
         }
@@ -197,76 +198,16 @@ const QuizApp = () => {
       )}
 
       {gameState === "answered" && (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            fontFamily: "Arial, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              fontSize: "30px",
-              fontWeight: "bold",
-              color: "orange",
-            }}
-          >
-            {resultTimeCount} 秒後に
-          </div>
-          <h3 style={{ color: "orange" }}>{`次のご挨拶いくよ`}</h3>
-
-          <div style={{ marginBottom: "20px", position: "relative" }}>
-            <img
-              src={quizData[justQuestion].image || "/placeholder.svg"}
-              alt="人物"
-              style={{ width: "auto", height: "250px" }}
-            />
-            <div
-              style={{   // タイムアップか正解不正解の表示
-                position: "absolute",
-                width: "120px",
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)",
-                backgroundColor: isTimeUp
-                  ? "rgba(130, 130, 130, 0.9)"   // グレー
-                  : isCorrect
-                    ? "rgba(0, 255, 0, 0.9)"     // 緑
-                    : "rgba(255, 0, 0, 0.9)",    // 赤
-                color:        "white",
-                padding:      "20px",
-                borderRadius: "5px",
-                fontSize:     "30px",
-                fontWeight:   "bold",
-              }}
-            >
-              {isTimeUp ? "時間切れ⏰" : isCorrect ? "正しい😊" : "違うで😠"}
-            </div>
-          </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px" }}>
-            {shuffledAnswers.map((answer, index) => (
-              <button
-                key={index}
-                style={{
-                  ...commonButtonStyle,
-                  backgroundColor:
-                    selectedAnswer === answer
-                      ? isCorrect && answer === quizData[justQuestion].justAnswer
-                        ? "lightgreen"
-                        : "red"
-                      : "skyblue",
-                  opacity: 0.5,
-                  boxShadow: "none",
-                }}
-                disabled
-              >
-                {answer}
-              </button>
-            ))}
-          </div>
-        </div>
+        <AnsweredPage
+        // 名前 = {親コンポーネントで定義した関数・変数（バリュー)}
+        nextTimeCount={nextTimeCount}
+        quizData={quizData}
+        justQuestion={justQuestion}
+        isTimeUp={isTimeUp}
+        isSuccess={isSuccess}
+        shuffledAnswers={shuffledAnswers}
+        selectedAnswer={selectedAnswer}
+        />
       )}
 
       {gameState === "finished" && (

--- a/src/QuizIndex.jsx
+++ b/src/QuizIndex.jsx
@@ -7,77 +7,77 @@ import { QuizSelectionPage } from "./components/QuizSelectionPage"
 const quizData = [
   {
     image: "/images/おはよう.png",
-    correctAnswer: "おはよう",
-    incorrectAnswers: ["ありがとう", "おめでとう"],
+    justAnswer: "おはよう",
+    fakeAnswer: ["ありがとう", "おめでとう"],
   },
   {
     image: "/images/おやすみ.png",
-    correctAnswer: "おやすみ",
-    incorrectAnswers: ["おみやげ", "おくやみ"],
+    justAnswer: "おやすみ",
+    fakeAnswer: ["おみやげ", "おくやみ"],
   },
   {
     image: "/images/ごちそうさま.png",
-    correctAnswer: "ごちそうさまでした",
-    incorrectAnswers: ["ごろつきそうでした", "ごまきがすきでした"],
+    justAnswer: "ごちそうさまでした",
+    fakeAnswer: ["ごろつきそうでした", "ごまきがすきでした"],
   },
   {
     image: "/images/夜露死苦.png",
-    correctAnswer: "夜露死苦",
-    incorrectAnswers: ["液露ﾀﾋ若", "夜露死若"],
+    justAnswer: "夜露死苦",
+    fakeAnswer: ["液露ﾀﾋ若", "夜露死若"],
   },
   {
     image: "/images/迷子の外国人.png",
-    correctAnswer: "Excuse me",
-    incorrectAnswers: ["Export me", "Ecstasy me"],
+    justAnswer: "Excuse me",
+    fakeAnswer: ["Export me", "Ecstasy me"],
   },
   {
     image: "/images/マサイ族.png",
-    correctAnswer: "éro",
-    incorrectAnswers: ["nabô ", "aré"],
+    justAnswer: "éro",
+    fakeAnswer: ["nabô", "aré"],
   },
   {
     image: "/images/沖縄.png",
-    correctAnswer: "くゎっちーさびたん",
-    incorrectAnswers: ["ちゅーをぅがなびら", "ひんぎれ"],
+    justAnswer: "くゎっちーさびたん",
+    fakeAnswer: ["ちゅーをぅがなびら", "ひんぎれ"],
   },
 
 ]
 
 const QuizApp = () => {
-  const [currentQuestion, setCurrentQuestion] = useState(0)
+  const [justQuestion, setJustQuestion] = useState(0)
   const [score, setScore] = useState(0)
   const [gameState, setGameState] = useState("start")     // start, playing, answered, finished
   const [shuffledAnswers, setShuffledAnswers] = useState([])
   const [selectedAnswer, setSelectedAnswer] = useState(null)
   const [isCorrect, setIsCorrect] = useState(false)
-  const [timeLeft, setTimeLeft] = useState(3)             // 出題タイマー
+  const [timeCount, setTimeCount] = useState(3)             // 出題タイマー
   const [isTimeUp, setIsTimeUp] = useState(false)         // タイムアップフラグ
-  const [resultTimeLeft, setResultTimeLeft] = useState(3) // 結果表示の3秒カウントダウン
+  const [resultTimeCount, setResultTimeCount] = useState(3) // 結果表示の3秒カウントダウン
 
   useEffect(() => {
-    if (currentQuestion < quizData.length) {
+    if (justQuestion < quizData.length) {
       shuffleAnswers()
     }
-  }, [currentQuestion])
+  }, [justQuestion])
 
   useEffect(() => {
     let timer
     if (gameState === "playing") {
-      setTimeLeft(3)             // 出題タイマー
+      setTimeCount(3)             // 出題タイマー
       setIsTimeUp(false)
 
       timer = setInterval(() => {
-        setTimeLeft((prevTime) => {
+        setTimeCount((prevTime) => {
           if (prevTime <= 1) {
             clearInterval(timer)
             // タイムアップ処理
             setIsTimeUp(true)
             setGameState("answered")
-            setResultTimeLeft(3) // 結果表示の3秒カウントダウンをセット
+            setResultTimeCount(3) // 結果表示の3秒カウントダウンをセット
 
             // 結果表示用のカウントダウンタイマーを開始
             const resultTimer = setInterval(() => {
-              setResultTimeLeft((prevTime) => {
+              setResultTimeCount((prevTime) => {
                 if (prevTime <= 1) {
                   clearInterval(resultTimer)
                   nextQuestion()
@@ -97,22 +97,22 @@ const QuizApp = () => {
     return () => {
       clearInterval(timer)
     }
-  }, [gameState, currentQuestion])
+  }, [gameState, justQuestion])
 
   const handleAnswer = (selectedAnswer) => {
     setSelectedAnswer(selectedAnswer)
-    const correct = selectedAnswer === quizData[currentQuestion].correctAnswer
+    const correct = selectedAnswer === quizData[justQuestion].justAnswer
     setIsCorrect(correct)
     if (correct) {
       setScore(score + 1)
     }
     setGameState("answered")
     setIsTimeUp(false)       // タイムアップをリセット
-    setResultTimeLeft(3)     // 結果表示の3秒カウントダウンをセット
+    setResultTimeCount(3)     // 結果表示の3秒カウントダウンをセット
 
     // 結果表示用のカウントダウンタイマーを開始
     const resultTimer = setInterval(() => {
-      setResultTimeLeft((prevTime) => {
+      setResultTimeCount((prevTime) => {
         if (prevTime <= 1) {
           clearInterval(resultTimer)
           nextQuestion()
@@ -124,14 +124,14 @@ const QuizApp = () => {
   }
 
   const shuffleAnswers = () => {   // 正解と間違いを
-    const currentQuizData = quizData[currentQuestion]
-    const allAnswers = [currentQuizData.correctAnswer, ...currentQuizData.incorrectAnswers]
+    const currentQuizData = quizData[justQuestion]
+    const allAnswers = [currentQuizData.justAnswer, ...currentQuizData.fakeAnswer]
     setShuffledAnswers(allAnswers.sort(() => Math.random() - 0.5))
   }
 
   const nextQuestion = () => {
-    if (currentQuestion + 1 < quizData.length) {
-      setCurrentQuestion(currentQuestion + 1)
+    if (justQuestion + 1 < quizData.length) {
+      setJustQuestion(justQuestion + 1)
       setSelectedAnswer(null)
       setGameState("playing")
       setIsTimeUp(false)      // タイムアップをリセット
@@ -141,7 +141,7 @@ const QuizApp = () => {
   }
 
   const restartQuiz = () => {
-    setCurrentQuestion(0)
+    setJustQuestion(0)
     setScore(0)
     setGameState("playing")
     setSelectedAnswer(null)
@@ -149,7 +149,7 @@ const QuizApp = () => {
   }
 
   const startGame = () => {
-    setCurrentQuestion(0)
+    setJustQuestion(0)
     setScore(0)
     setGameState("playing")
     setSelectedAnswer(null)
@@ -179,7 +179,8 @@ const QuizApp = () => {
 
       {gameState === "start" && (
         <TopPage
-          // 名前 = {バリュー(値)}
+          // 名前 = {親コンポーネントで定義した関数・変数（バリュー)}
+          // 名前 = "親コンポーネントで文字列を渡す"
           handleClick={startGame}
         />
       )}
@@ -188,6 +189,10 @@ const QuizApp = () => {
       {gameState === "playing" && (
         <QuizSelectionPage
           selectedAnswer={handleAnswer}
+          timeCount={timeCount}
+          quizData={quizData}
+          justQuestion={justQuestion}
+          shuffledAnswers={shuffledAnswers}
         />
       )}
 
@@ -208,13 +213,13 @@ const QuizApp = () => {
               color: "orange",
             }}
           >
-            {resultTimeLeft} 秒後に
+            {resultTimeCount} 秒後に
           </div>
           <h3 style={{ color: "orange" }}>{`次のご挨拶いくよ`}</h3>
 
           <div style={{ marginBottom: "20px", position: "relative" }}>
             <img
-              src={quizData[currentQuestion].image || "/placeholder.svg"}
+              src={quizData[justQuestion].image || "/placeholder.svg"}
               alt="人物"
               style={{ width: "auto", height: "250px" }}
             />
@@ -248,7 +253,7 @@ const QuizApp = () => {
                   ...commonButtonStyle,
                   backgroundColor:
                     selectedAnswer === answer
-                      ? isCorrect && answer === quizData[currentQuestion].correctAnswer
+                      ? isCorrect && answer === quizData[justQuestion].justAnswer
                         ? "lightgreen"
                         : "red"
                       : "skyblue",

--- a/src/QuizIndex.jsx
+++ b/src/QuizIndex.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { TopPage } from "./components/TopPage"
 import { QuizSelectionPage } from "./components/QuizSelectionPage"
 import { AnsweredPage } from "./components/AnsweredPage"
+import { FinishedPage } from "./components/FinishedPage"
 
 const quizData = [
   {
@@ -51,9 +52,9 @@ const QuizApp = () => {
   const [shuffledAnswers, setShuffledAnswers] = useState([])
   const [selectedAnswer, setSelectedAnswer] = useState(null)
   const [isSuccess, setIsSuccess] = useState(false)
-  const [timeCount, setTimeCount] = useState(3)             // 出題タイマー
+  const [timeCount, setTimeCount] = useState(3)           // 出題タイマー
   const [isTimeUp, setIsTimeUp] = useState(false)         // タイムアップフラグ
-  const [nextTimeCount, setNextTimeCount] = useState(2) // 結果表示の2秒カウントダウン
+  const [nextTimeCount, setNextTimeCount] = useState(2)   // 結果表示の2秒カウントダウン
 
   useEffect(() => {
     if (justQuestion < quizData.length) {
@@ -74,7 +75,7 @@ const QuizApp = () => {
             // タイムアップ処理
             setIsTimeUp(true)
             setGameState("answered")
-            setNextTimeCount(2) // 結果表示の2秒カウントダウンをセット
+            setNextTimeCount(2)   // 結果表示の2秒カウントダウンをセット
 
             // 結果表示用のカウントダウンタイマーを開始
             const nextTimer = setInterval(() => {
@@ -109,7 +110,7 @@ const QuizApp = () => {
     }
     setGameState("answered")
     setIsTimeUp(false)       // タイムアップをリセット
-    setNextTimeCount(2)     // 結果表示の2秒カウントダウンをセット
+    setNextTimeCount(2)      // 結果表示の2秒カウントダウンをセット
 
     // 結果表示用のカウントダウンタイマーを開始
     const nextTimer = setInterval(() => {
@@ -186,7 +187,6 @@ const QuizApp = () => {
         />
       )}
 
-
       {gameState === "playing" && (
         <QuizSelectionPage
           selectedAnswer={handleAnswer}
@@ -199,7 +199,6 @@ const QuizApp = () => {
 
       {gameState === "answered" && (
         <AnsweredPage
-        // 名前 = {親コンポーネントで定義した関数・変数（バリュー)}
         nextTimeCount={nextTimeCount}
         quizData={quizData}
         justQuestion={justQuestion}
@@ -211,44 +210,14 @@ const QuizApp = () => {
       )}
 
       {gameState === "finished" && (
-        <div
-          style={{
-            backgroundImage: `url(/images/背景.png)`,
-            backgroundSize: 'cover',
-            position: 'fixed',
-            width: '100vw', // 画面幅に合わせる
-            height: '100%',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            alignItems: 'center',
-            }}>
-
-          <h3 style={{ fontSize: "30px", color: "orange", marginBottom: "30px" }}>
-            {quizData.length}人中、 {score}人に好かれた！
-          </h3>
-
-          <button
-            onClick={restartQuiz}
-            style={{
-              ...commonButtonStyle,
-              backgroundColor: "violet",
-            }}
-            onMouseOver={(e) => {
-              e.currentTarget.style.backgroundColor = "orange"
-              e.currentTarget.style.boxShadow = "none"
-            }}
-            onMouseOut={(e) => {
-              e.currentTarget.style.backgroundColor = "violet"
-              e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
-            }}
-          >
-            もっかい好かれに行く
-          </button>
-        </div>
+        <FinishedPage
+          restartQuiz={restartQuiz}
+          quizData={quizData}
+          score={score}
+        />
       )}
     </div>
   )
 }
 
 export default QuizApp
-

--- a/src/components/AnsweredPage.jsx
+++ b/src/components/AnsweredPage.jsx
@@ -1,4 +1,3 @@
-// 選ばれた選択肢の答えを表示しながら、３秒をカウントする画面です！（２秒に変更しますが）
 const commonButtonStyle = {
   padding: "10px 25px",
   border: "none",
@@ -10,8 +9,7 @@ const commonButtonStyle = {
   transition: "background-color 0.3s, box-shadow 0.3s",
 }
 
-export const AnsweredPage = ({
-  nextTimeCount, quizData, justQuestion, isTimeUp, isSuccess, shuffledAnswers, selectedAnswer}) => {
+export const AnsweredPage = ({nextTimeCount, quizData, justQuestion, isTimeUp, isSuccess, shuffledAnswers, selectedAnswer}) => {
 
   return (
     <div

--- a/src/components/AnsweredPage.jsx
+++ b/src/components/AnsweredPage.jsx
@@ -1,0 +1,88 @@
+// 選ばれた選択肢の答えを表示しながら、３秒をカウントする画面です！（２秒に変更しますが）
+const commonButtonStyle = {
+  padding: "10px 25px",
+  border: "none",
+  borderRadius: "10px",
+  color: "white",
+  fontSize: "20px",
+  cursor: "pointer",
+  boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)",
+  transition: "background-color 0.3s, box-shadow 0.3s",
+}
+
+export const AnsweredPage = ({
+  nextTimeCount, quizData, justQuestion, isTimeUp, isSuccess, shuffledAnswers, selectedAnswer}) => {
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "Arial, sans-serif",
+      }}
+      >
+      <div
+        style={{
+          fontSize: "30px",
+          fontWeight: "bold",
+          color: "orange",
+        }}
+      >
+        {nextTimeCount} 秒後に
+      </div>
+      <h3 style={{ color: "orange" }}>{`次のご挨拶いくよ`}</h3>
+
+      <div style={{ marginBottom: "20px", position: "relative" }}>
+        <img
+          src={quizData[justQuestion].image || "/placeholder.svg"}
+          alt="人物"
+          style={{ width: "auto", height: "250px" }}
+        />
+        <div
+          style={{   // タイムアップか正解不正解の表示
+            position: "absolute",
+            width: "120px",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            backgroundColor: isTimeUp
+              ? "rgba(130, 130, 130, 0.9)"   // グレー
+              : isSuccess
+                ? "rgba(0, 255, 0, 0.9)"     // 緑
+                : "rgba(255, 0, 0, 0.9)",    // 赤
+            color:        "white",
+            padding:      "20px",
+            borderRadius: "5px",
+            fontSize:     "30px",
+            fontWeight:   "bold",
+          }}
+        >
+          {isTimeUp ? "時間切れ⏰" : isSuccess ? "正しい😊" : "違うで😠"}
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px" }}>
+        {shuffledAnswers.map((answer, index) => (
+          <button
+            key={index}
+            style={{
+              ...commonButtonStyle,
+              backgroundColor:
+                selectedAnswer === answer
+                  ? isSuccess && answer === quizData[justQuestion].justAnswer
+                    ? "lightgreen"
+                    : "red"
+                  : "skyblue",
+              opacity: 0.5,
+              boxShadow: "none",
+            }}
+            disabled
+          >
+            {answer}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/FinishedPage.jsx
+++ b/src/components/FinishedPage.jsx
@@ -1,0 +1,49 @@
+const commonButtonStyle = {
+  padding: "10px 25px",
+  border: "none",
+  borderRadius: "10px",
+  color: "white",
+  fontSize: "20px",
+  cursor: "pointer",
+  boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)",
+  transition: "background-color 0.3s, box-shadow 0.3s",
+}
+
+export const FinishedPage = ({restartQuiz, quizData, score}) => {
+  return (
+    <div
+      style={{
+        backgroundImage: `url(/images/背景.png)`,
+        backgroundSize: 'cover',
+        position: 'fixed',
+        width: '100vw', // 画面幅に合わせる
+        height: '80vw',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+
+      <h3 style={{ fontSize: "30px", color: "orange", marginBottom: "30px" }}>
+        {quizData.length}人中、 {score}人に好かれた！
+      </h3>
+
+      <button
+        onClick={restartQuiz}
+        style={{
+          ...commonButtonStyle,
+          backgroundColor: "violet",
+        }}
+        onMouseOver={(e) => {
+          e.currentTarget.style.backgroundColor = "orange"
+          e.currentTarget.style.boxShadow = "none"
+        }}
+        onMouseOut={(e) => {
+          e.currentTarget.style.backgroundColor = "violet"
+          e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
+        }}
+      >
+        もっかい好かれに行く
+      </button>
+  </div>
+  )
+}

--- a/src/components/QuizSelectionPage.jsx
+++ b/src/components/QuizSelectionPage.jsx
@@ -1,0 +1,62 @@
+
+const commonButtonStyle = {
+  padding: "10px 25px",
+  border: "none",
+  borderRadius: "10px",
+  color: "white",
+  fontSize: "20px",
+  cursor: "pointer",
+  boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)",
+  transition: "background-color 0.3s, box-shadow 0.3s",
+}
+
+export const QuizSelectionPage = ({selectedAnswer, timeCount, quizData, justQuestion, shuffledAnswers}) => {
+
+  return (
+    <>
+      <div>
+        <div
+          style={{
+            fontSize: "30px",
+            fontWeight: "bold",
+            color: timeCount <= 2 ? "red" : "orange",
+          }}
+        >
+          {timeCount} 秒以内に
+        </div>
+        <h3 style={{ color: "orange" }}>{`ご挨拶しよう！`}</h3>
+
+        <div style={{ marginBottom: "20px" }}>
+          <img
+            src={quizData[justQuestion].image}
+            alt="人物"
+            style={{ width: "auto", height: "250px" }}
+          />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px", margin: "0 auto" }}>
+          {shuffledAnswers.map((answer, index) => (
+            <button
+              key={index}
+              onClick={() => selectedAnswer(answer)}
+              style={{
+                ...commonButtonStyle,
+                backgroundColor: "#00BBFF", // ほどよい青
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.backgroundColor = "orange"
+                e.currentTarget.style.boxShadow = "none"
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.backgroundColor = "#00BBFF"  // ほどよい青
+                e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
+              }}
+            >
+              {answer}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+
+}

--- a/src/components/TopPage.jsx
+++ b/src/components/TopPage.jsx
@@ -1,0 +1,43 @@
+
+const commonButtonStyle = {
+  padding: "10px 25px",
+  border: "none",
+  borderRadius: "10px",
+  color: "white",
+  fontSize: "20px",
+  cursor: "pointer",
+  boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)",
+  transition: "background-color 0.3s, box-shadow 0.3s",
+}
+
+
+export const TopPage = ({ handleClick }) => {
+
+  return (
+    <>
+      <div>
+        <h3 style={{ color: "orange", marginBottom: "20px" }}>全人類の基本をクリアせよ！</h3>
+        <div style={{ marginBottom: "30px" }}>
+          <img src="/images/ご挨拶.png" alt="スタート画面" style={{ width: "auto", height: "250px" }} />
+        </div>
+        <button
+          onClick={handleClick}
+          style={{
+            ...commonButtonStyle,
+            backgroundColor: "violet",
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.backgroundColor = "orange"
+            e.currentTarget.style.boxShadow = "none"
+          }}
+          onMouseOut={(e) => {
+            e.currentTarget.style.backgroundColor = "violet"
+            e.currentTarget.style.boxShadow = "0 4px 8px rgba(0, 0, 0, 0.2)"
+          }}
+        >
+          みんなに好かれにいく
+        </button>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
# fix: 親コンポーネントから子コンポーネントを切り分け
**できるようになったこと**
- https://high-speed-greetings-quiz.vercel.app/
- **変更前**
    [![Image from Gyazo](https://i.gyazo.com/6ab6b569d6bf8c88dea2c10145f170a6.gif)](https://gyazo.com/6ab6b569d6bf8c88dea2c10145f170a6)
- **変更後**（回答後の画面の表示は３秒間から２秒間に変更しました）
  [![Image from Gyazo](https://i.gyazo.com/5f4239d98dda72dd6995e910f9561d96.gif)](https://gyazo.com/5f4239d98dda72dd6995e910f9561d96)
____
当ミニアプリは
### 「Reactのキャッチアップの為、"書く力"より先に"読み取って修正する力"をつけるためのミニアプリ」
です。
なので、このクイズアプリのコード（`src/QuizIndex.jsx`）はV0というAIに書かせました。
そこから自分の分かる範囲で、手動で修正を加えたのがこのプルリクです。
　
　
**しなかったこと**（以下は、次回の手動で実装する内容です）
- `commonButtonStyle`（統一したボタンのスタイル）を、親コンポーネントから受け継ぐこと
  - 今回は、一旦切り分けた各子コンポーネントに直接`commonButtonStyle`を記載しています


　
**今回、手動で実行したこと**
- `src/quiz-app.jsx`を`src/QuizIndex.jsx`に改名
  - 回答後の画面の表示は３秒間から２秒間に変更しました
- `src/components`ディレクトリを作成し
- 親コンポーネント（`src/QuizIndex.jsx`）から子コンポーネントを切り分け
  - `src/components/AnsweredPage.jsx`：回答後の２秒間で表示される画面
  - `src/components/FinishedPage.jsx`：全問題が終了した際に表示される画面
  - `src/components/QuizSelectionPage.jsx`：３秒間 問題と選択肢が表示され、選択肢を選べる画面
  - `src/components/TopPage.jsx`：スタートボタンを押す画面