### PR TITLE
fix: `useState`を使ってホバー時のボタンのスタイルを共通化

### DIFF
--- a/src/components/FinishedPage.jsx
+++ b/src/components/FinishedPage.jsx
@@ -1,8 +1,16 @@
-import { globalButtonStyle } from '../styles/globalButton';
+import { useState } from 'react';
+import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
 import { XShareButton } from '../styles/xShareButton';
 
 export const FinishedPage = ({restartQuiz, quizData, score}) => {
 
+  const [isHovered, setIsHovered] = useState(false);
+
+  const buttonStyle = {   // このコンポーネントでのボタンのスタイルを指定
+    ...globalButtonStyle,
+    backgroundColor: isHovered ? globalButtonHoverStyle.backgroundColor : "violet",
+    boxShadow: isHovered ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
+  };
   return (
     <div
       style={{
@@ -26,18 +34,9 @@ export const FinishedPage = ({restartQuiz, quizData, score}) => {
 
       <button
         onClick={restartQuiz}
-        style={{
-          ...globalButtonStyle,
-          backgroundColor: "violet",
-        }}
-        onMouseOver={(e) => {
-          e.currentTarget.style.backgroundColor = "orange"
-          e.currentTarget.style.boxShadow = "none"
-        }}
-        onMouseOut={(e) => {
-          e.currentTarget.style.backgroundColor = "violet"
-          e.currentTarget.style.boxShadow = "0 4px 8px rgb(250, 150, 0, 0.6)"
-        }}
+        style={buttonStyle}
+        onMouseOver={() => setIsHovered(true)}
+        onMouseOut={() => setIsHovered(false)}
       >
         もっかい好かれに行く
       </button>

--- a/src/components/QuizSelectionPage.jsx
+++ b/src/components/QuizSelectionPage.jsx
@@ -1,52 +1,47 @@
-import { globalButtonStyle } from '../styles/globalButton';
+import { useState } from 'react';
+import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
 
 export const QuizSelectionPage = ({selectedAnswer, timeCount, quizData, justQuestion, shuffledAnswers}) => {
 
+  const [isHovered, setIsHovered] = useState(false);
+
   return (
-    <>
-      <div>
-        <div
-          style={{
-            fontSize: "30px",
-            fontWeight: "bold",
-            color: timeCount <= 2 ? "red" : "orange",
-          }}
-        >
-          {timeCount} 秒以内に
-        </div>
-        <h3 style={{ color: "orange" }}>{`ご挨拶しよう！`}</h3>
-
-        <div style={{ marginBottom: "20px" }}>
-          <img
-            src={quizData[justQuestion].image}
-            alt="人物"
-            style={{ width: "auto", height: "250px" }}
-          />
-        </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px", margin: "0 auto" }}>
-          {shuffledAnswers.map((answer, index) => (
-            <button
-              key={index}
-              onClick={() => selectedAnswer(answer)}
-              style={{
-                ...globalButtonStyle,
-                backgroundColor: "#00BBFF", // ほどよい青
-              }}
-              onMouseOver={(e) => {
-                e.currentTarget.style.backgroundColor = "orange"
-                e.currentTarget.style.boxShadow = "none"
-              }}
-              onMouseOut={(e) => {
-                e.currentTarget.style.backgroundColor = "#00BBFF"  // ほどよい青
-                e.currentTarget.style.boxShadow = "0 4px 8px rgb(250, 150, 0, 0.6)"
-              }}
-            >
-              {answer}
-            </button>
-          ))}
-        </div>
+    <div>
+      <div
+        style={{
+          fontSize: "30px",
+          fontWeight: "bold",
+          color: timeCount <= 2 ? "red" : "orange",
+        }}
+      >
+        {timeCount} 秒以内に
       </div>
-    </>
-  )
+      <h3 style={{ color: "orange" }}>{`ご挨拶しよう！`}</h3>
 
+      <div style={{ marginBottom: "20px" }}>
+        <img
+          src={quizData[justQuestion].image}
+          alt="人物"
+          style={{ width: "auto", height: "250px" }}
+        />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px", margin: "0 auto" }}>
+        {shuffledAnswers.map((answer, index) => (
+          <button
+            key={index}
+            onClick={() => selectedAnswer(answer)}
+            style={{
+              ...globalButtonStyle,
+              backgroundColor: isHovered === index ? globalButtonHoverStyle.backgroundColor : "#00BBFF",
+              boxShadow: isHovered === index ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
+            }}
+            onMouseOver={() => setIsHovered(index)}
+            onMouseOut={() => setIsHovered(null)}
+          >
+            {answer}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/components/TopPage.jsx
+++ b/src/components/TopPage.jsx
@@ -1,32 +1,29 @@
-import { globalButtonStyle } from '../styles/globalButton';
+import { useState } from 'react';
+import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
 
 export const TopPage = ({ handleClick }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const buttonStyle = {   // このコンポーネントでのボタンのスタイルを指定
+    ...globalButtonStyle,
+    backgroundColor: isHovered ? globalButtonHoverStyle.backgroundColor : "violet",
+    boxShadow: isHovered ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
+  };
 
   return (
-    <>
-      <div>
-        <h3 style={{ color: "orange", marginBottom: "20px" }}>全人類の基本をクリアせよ！</h3>
-        <div style={{ marginBottom: "30px" }}>
-          <img src="/images/ご挨拶.png" alt="スタート画面" style={{ width: "auto", height: "250px" }} />
-        </div>
-        <button
-          onClick={handleClick}
-          style={{
-            ...globalButtonStyle,
-            backgroundColor: "violet",
-          }}
-          onMouseOver={(e) => {
-            e.currentTarget.style.backgroundColor = "orange"
-            e.currentTarget.style.boxShadow = "none"
-          }}
-          onMouseOut={(e) => {
-            e.currentTarget.style.backgroundColor = "violet"
-            e.currentTarget.style.boxShadow = "0 4px 8px rgb(250, 150, 0, 0.6)"
-          }}
-        >
-          みんなに好かれにいく
-        </button>
+    <div>
+      <h3 style={{ color: "orange", marginBottom: "20px" }}>全人類の基本をクリアせよ！</h3>
+      <div style={{ marginBottom: "30px" }}>
+        <img src="/images/ご挨拶.png" alt="スタート画面" style={{ width: "auto", height: "250px" }} />
       </div>
-    </>
+      <button
+        onClick={handleClick}
+        style={buttonStyle}
+        onMouseOver={() => setIsHovered(true)}
+        onMouseOut={() => setIsHovered(false)}
+      >
+        みんなに好かれにいく
+      </button>
+    </div>
   )
 }

--- a/src/styles/globalButton.jsx
+++ b/src/styles/globalButton.jsx
@@ -7,3 +7,8 @@ export const globalButtonStyle = {
   cursor: "pointer",
   boxShadow: "0 4px 8px rgb(250, 150, 0, 0.6)",
 };
+
+export const globalButtonHoverStyle = {
+  backgroundColor: "orange",
+  boxShadow: "none",
+};


### PR DESCRIPTION
# fix: `useState`を使ってホバー時のボタンのスタイルを共通化
**できるようになったこと**
- https://high-speed-greetings-quiz.vercel.app/
  ユーザーにとっては変化なし


**実装**
- `src/styles/globalButton.jsx`に追記
  - 共通化したいボタンホバー時のスタイルを関数で定義
- `useState`を使ってホバーか否かを取得し、`globalButton.jsx`から呼び出したい関数を切り分け
  -  ボタンが複数存在するので、`useState`と`buttonStyle`を定義し  
    `button`タグの`style`を三項演算子で使うスタイルの関数を変化したファイル
      - `src/components/QuizSelectionPage.jsx`
  - ボタンが１つしか存在しないので、`useState`と`buttonStyle`を定義したファイル
    - `src/components/FinishedPage.jsx`
    - `src/components/TopPage.jsx`