### PR TITLE
add: Prettierを導入し、コマンドでフォーマットを実行できるようにする

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Ignore artifacts:
+build
+coverage
+
+# Ignore specific files:
+.github/PULL_REQUEST_TEMPLATE.md
+README.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": false,
+  "endOfLine": "auto",
+  "trailingComma": "none",
+  "bracketSpacing": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "svgo": "^2.8.0",
         "web-vitals": "^2.1.4",
         "yocto-queue": "^1.2.0"
+      },
+      "devDependencies": {
+        "prettier": "3.5.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13653,6 +13656,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier . --write"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "3.5.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,35 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="white" />
     <title>高速ご挨拶クイズ</title>
 
-    <meta property="og:url" content="https://high-speed-greetings-quiz.vercel.app/" />
+    <meta
+      property="og:url"
+      content="https://high-speed-greetings-quiz.vercel.app/"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="高速ご挨拶クイズ" />
     <meta property="og:description" content="全人類の基本ををクリアせよ！" />
     <meta property="og:site_name" content="高速ご挨拶クイズ" />
-    <meta property="og:image" content="https://high-speed-greetings-quiz.vercel.app/images/OGP.png" />
+    <meta
+      property="og:image"
+      content="https://high-speed-greetings-quiz.vercel.app/images/OGP.png"
+    />
 
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@pakira_rrr">
-    <meta name="twitter:title" content="高速ご挨拶クイズ">
-    <meta name="twitter:description" content="全人類の基本ををクリアせよ！">
-    <meta name="twitter:image" content="https://high-speed-greetings-quiz.vercel.app/images/OGP.png" />
-
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@pakira_rrr" />
+    <meta name="twitter:title" content="高速ご挨拶クイズ" />
+    <meta name="twitter:description" content="全人類の基本ををクリアせよ！" />
+    <meta
+      name="twitter:image"
+      content="https://high-speed-greetings-quiz.vercel.app/images/OGP.png"
+    />
   </head>
   <body>
     <div id="root"></div>
-
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
-import QuizApp from './QuizIndex';
+import React from "react"
+import QuizApp from "./QuizIndex"
 
 function App() {
   return (
     <div className="App">
       <QuizApp />
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/QuizIndex.jsx
+++ b/src/QuizIndex.jsx
@@ -10,56 +10,55 @@ const quizData = [
   {
     image: "/images/おはよう.png",
     justAnswer: "おはよう",
-    fakeAnswer: ["ありがとう", "おめでとう"],
+    fakeAnswer: ["ありがとう", "おめでとう"]
   },
   {
     image: "/images/おやすみ.png",
     justAnswer: "おやすみ",
-    fakeAnswer: ["おみやげ", "おくやみ"],
+    fakeAnswer: ["おみやげ", "おくやみ"]
   },
   {
     image: "/images/ごちそうさま.png",
     justAnswer: "ごちそうさまでした",
-    fakeAnswer: ["ごろつきそうでした", "ごまきがすきでした"],
+    fakeAnswer: ["ごろつきそうでした", "ごまきがすきでした"]
   },
   {
     image: "/images/夜露死苦.png",
     justAnswer: "夜露死苦",
-    fakeAnswer: ["液露ﾀﾋ若", "夜露死若"],
+    fakeAnswer: ["液露ﾀﾋ若", "夜露死若"]
   },
   {
     image: "/images/迷子の外国人.png",
     justAnswer: "Excuse me",
-    fakeAnswer: ["Export me", "Ecstasy me"],
+    fakeAnswer: ["Export me", "Ecstasy me"]
   },
   {
     image: "/images/マサイ族.png",
     justAnswer: "éro",
-    fakeAnswer: ["nabô", "aré"],
+    fakeAnswer: ["nabô", "aré"]
   },
   {
     image: "/images/タイ.png",
     justAnswer: "サワディー カー",
-    fakeAnswer: ["サワディークラップ", "サワムラークラップ"],
+    fakeAnswer: ["サワディークラップ", "サワムラークラップ"]
   },
   {
     image: "/images/沖縄.png",
     justAnswer: "くゎっちーさびたん",
-    fakeAnswer: ["ちゅーをぅがなびら", "ひんぎれ"],
-  },
-
+    fakeAnswer: ["ちゅーをぅがなびら", "ひんぎれ"]
+  }
 ]
 
 const QuizApp = () => {
   const [justQuestion, setJustQuestion] = useState(0)
   const [score, setScore] = useState(0)
-  const [gameState, setGameState] = useState("start")     // start, playing, answered, finished
+  const [gameState, setGameState] = useState("start") // start, playing, answered, finished
   const [shuffledAnswers, setShuffledAnswers] = useState([])
   const [selectedAnswer, setSelectedAnswer] = useState(null)
   const [isSuccess, setIsSuccess] = useState(false)
-  const [timeCount, setTimeCount] = useState(3)           // 出題タイマー
-  const [isTimeUp, setIsTimeUp] = useState(false)         // タイムアップフラグ
-  const [nextTimeCount, setNextTimeCount] = useState(2)   // 結果表示の2秒カウントダウン
+  const [timeCount, setTimeCount] = useState(3) // 出題タイマー
+  const [isTimeUp, setIsTimeUp] = useState(false) // タイムアップフラグ
+  const [nextTimeCount, setNextTimeCount] = useState(2) // 結果表示の2秒カウントダウン
 
   useEffect(() => {
     if (justQuestion < quizData.length) {
@@ -70,7 +69,7 @@ const QuizApp = () => {
   useEffect(() => {
     let timer
     if (gameState === "playing") {
-      setTimeCount(3)             // 出題タイマー
+      setTimeCount(3) // 出題タイマー
       setIsTimeUp(false)
 
       timer = setInterval(() => {
@@ -80,7 +79,7 @@ const QuizApp = () => {
             // タイムアップ処理
             setIsTimeUp(true)
             setGameState("answered")
-            setNextTimeCount(2)   // 結果表示の2秒カウントダウンをセット
+            setNextTimeCount(2) // 結果表示の2秒カウントダウンをセット
 
             // 結果表示用のカウントダウンタイマーを開始
             const nextTimer = setInterval(() => {
@@ -114,8 +113,8 @@ const QuizApp = () => {
       setScore(score + 1)
     }
     setGameState("answered")
-    setIsTimeUp(false)       // タイムアップをリセット
-    setNextTimeCount(2)      // 結果表示の2秒カウントダウンをセット
+    setIsTimeUp(false) // タイムアップをリセット
+    setNextTimeCount(2) // 結果表示の2秒カウントダウンをセット
 
     // 結果表示用のカウントダウンタイマーを開始
     const nextTimer = setInterval(() => {
@@ -130,9 +129,13 @@ const QuizApp = () => {
     }, 1000)
   }
 
-  const shuffleAnswers = () => {   // 正解と間違いを
+  const shuffleAnswers = () => {
+    // 正解と間違いを
     const currentQuizData = quizData[justQuestion]
-    const allAnswers = [currentQuizData.justAnswer, ...currentQuizData.fakeAnswer]
+    const allAnswers = [
+      currentQuizData.justAnswer,
+      ...currentQuizData.fakeAnswer
+    ]
     setShuffledAnswers(allAnswers.sort(() => Math.random() - 0.5))
   }
 
@@ -141,7 +144,7 @@ const QuizApp = () => {
       setJustQuestion(justQuestion + 1)
       setSelectedAnswer(null)
       setGameState("playing")
-      setIsTimeUp(false)      // タイムアップをリセット
+      setIsTimeUp(false) // タイムアップをリセット
     } else {
       setGameState("finished")
     }
@@ -152,7 +155,7 @@ const QuizApp = () => {
     setScore(0)
     setGameState("playing")
     setSelectedAnswer(null)
-    setIsTimeUp(false)        // タイムアップをリセット
+    setIsTimeUp(false) // タイムアップをリセット
   }
 
   const startGame = () => {
@@ -163,15 +166,22 @@ const QuizApp = () => {
     setIsTimeUp(false)
   }
 
-
   return (
     <div
       style={{
         fontFamily: "Arial, sans-serif",
-        textAlign: "center",
+        textAlign: "center"
       }}
     >
-      <h1 style={{ color: "red", backgroundColor: "lightyellow", marginBottom: "15px" }}>高速ご挨拶クイズ</h1>
+      <h1
+        style={{
+          color: "red",
+          backgroundColor: "lightyellow",
+          marginBottom: "15px"
+        }}
+      >
+        高速ご挨拶クイズ
+      </h1>
 
       {gameState === "start" && (
         <TopPage
@@ -193,13 +203,13 @@ const QuizApp = () => {
 
       {gameState === "answered" && (
         <AnsweredPage
-        nextTimeCount={nextTimeCount}
-        quizData={quizData}
-        justQuestion={justQuestion}
-        isTimeUp={isTimeUp}
-        isSuccess={isSuccess}
-        shuffledAnswers={shuffledAnswers}
-        selectedAnswer={selectedAnswer}
+          nextTimeCount={nextTimeCount}
+          quizData={quizData}
+          justQuestion={justQuestion}
+          isTimeUp={isTimeUp}
+          isSuccess={isSuccess}
+          shuffledAnswers={shuffledAnswers}
+          selectedAnswer={selectedAnswer}
         />
       )}
 

--- a/src/components/AnsweredPage.jsx
+++ b/src/components/AnsweredPage.jsx
@@ -1,7 +1,14 @@
-import { globalButtonStyle } from '../styles/globalButton';
+import { globalButtonStyle } from "../styles/globalButton"
 
-export const AnsweredPage = ({nextTimeCount, quizData, justQuestion, isTimeUp, isSuccess, shuffledAnswers, selectedAnswer}) => {
-
+export const AnsweredPage = ({
+  nextTimeCount,
+  quizData,
+  justQuestion,
+  isTimeUp,
+  isSuccess,
+  shuffledAnswers,
+  selectedAnswer
+}) => {
   return (
     <div
       style={{
@@ -9,14 +16,14 @@ export const AnsweredPage = ({nextTimeCount, quizData, justQuestion, isTimeUp, i
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        fontFamily: "Arial, sans-serif",
+        fontFamily: "Arial, sans-serif"
       }}
-      >
+    >
       <div
         style={{
           fontSize: "30px",
           fontWeight: "bold",
-          color: "orange",
+          color: "orange"
         }}
       >
         {nextTimeCount} 秒後に
@@ -30,28 +37,36 @@ export const AnsweredPage = ({nextTimeCount, quizData, justQuestion, isTimeUp, i
           style={{ width: "auto", height: "250px" }}
         />
         <div
-          style={{   // タイムアップか正解不正解の表示
+          style={{
+            // タイムアップか正解不正解の表示
             position: "absolute",
             width: "120px",
             top: "50%",
             left: "50%",
             transform: "translate(-50%, -50%)",
             backgroundColor: isTimeUp
-              ? "rgba(130, 130, 130, 0.9)"   // グレー
+              ? "rgba(130, 130, 130, 0.9)" // グレー
               : isSuccess
-                ? "rgba(0, 255, 0, 0.9)"     // 緑
-                : "rgba(255, 0, 0, 0.9)",    // 赤
-            color:        "white",
-            padding:      "20px",
+                ? "rgba(0, 255, 0, 0.9)" // 緑
+                : "rgba(255, 0, 0, 0.9)", // 赤
+            color: "white",
+            padding: "20px",
             borderRadius: "5px",
-            fontSize:     "30px",
-            fontWeight:   "bold",
+            fontSize: "30px",
+            fontWeight: "bold"
           }}
         >
           {isTimeUp ? "時間切れ" : isSuccess ? "しゅきぃ" : "ちゃうで"}
         </div>
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "15px",
+          width: "230px"
+        }}
+      >
         {shuffledAnswers.map((answer, index) => (
           <button
             key={index}
@@ -64,7 +79,7 @@ export const AnsweredPage = ({nextTimeCount, quizData, justQuestion, isTimeUp, i
                     : "red"
                   : "skyblue",
               opacity: 0.5,
-              boxShadow: "none",
+              boxShadow: "none"
             }}
             disabled
           >

--- a/src/components/FinishedPage.jsx
+++ b/src/components/FinishedPage.jsx
@@ -1,34 +1,48 @@
-import { useState } from 'react';
-import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
-import { XShareButton } from '../styles/xShareButton';
+import { useState } from "react"
+import {
+  globalButtonStyle,
+  globalButtonHoverStyle
+} from "../styles/globalButton"
+import { XShareButton } from "../styles/xShareButton"
 
-export const FinishedPage = ({restartQuiz, quizData, score}) => {
+export const FinishedPage = ({ restartQuiz, quizData, score }) => {
+  const [isHovered, setIsHovered] = useState(false)
 
-  const [isHovered, setIsHovered] = useState(false);
-
-  const buttonStyle = {   // このコンポーネントでのボタンのスタイルを指定
+  const buttonStyle = {
+    // このコンポーネントでのボタンのスタイルを指定
     ...globalButtonStyle,
-    backgroundColor: isHovered ? globalButtonHoverStyle.backgroundColor : "violet",
-    boxShadow: isHovered ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
-  };
+    backgroundColor: isHovered
+      ? globalButtonHoverStyle.backgroundColor
+      : "violet",
+    boxShadow: isHovered
+      ? globalButtonHoverStyle.boxShadow
+      : globalButtonStyle.boxShadow
+  }
   return (
     <div
       style={{
         backgroundImage: `url(/images/背景.png)`,
-        backgroundSize: 'cover',
-        position: 'fixed',
-        width: '100vw', // 画面幅に合わせる
-        height: '80vw',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}>
-
-      <h3 style={{ fontSize: "30px", color: "red", backgroundColor: "#ffeeff",marginBottom: "0px" }}>
+        backgroundSize: "cover",
+        position: "fixed",
+        width: "100vw", // 画面幅に合わせる
+        height: "80vw",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center"
+      }}
+    >
+      <h3
+        style={{
+          fontSize: "30px",
+          color: "red",
+          backgroundColor: "#ffeeff",
+          marginBottom: "0px"
+        }}
+      >
         {quizData.length}人中、 {score}人に好かれた！
       </h3>
 
-      <div style={{justifyContent: "center", marginBottom: "40px" }}>
+      <div style={{ justifyContent: "center", marginBottom: "40px" }}>
         <XShareButton quizData={quizData} score={score} />
       </div>
 
@@ -40,6 +54,6 @@ export const FinishedPage = ({restartQuiz, quizData, score}) => {
       >
         もっかい好かれに行く
       </button>
-  </div>
+    </div>
   )
 }

--- a/src/components/QuizSelectionPage.jsx
+++ b/src/components/QuizSelectionPage.jsx
@@ -1,9 +1,17 @@
-import { useState } from 'react';
-import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
+import { useState } from "react"
+import {
+  globalButtonStyle,
+  globalButtonHoverStyle
+} from "../styles/globalButton"
 
-export const QuizSelectionPage = ({selectedAnswer, timeCount, quizData, justQuestion, shuffledAnswers}) => {
-
-  const [isHovered, setIsHovered] = useState(false);
+export const QuizSelectionPage = ({
+  selectedAnswer,
+  timeCount,
+  quizData,
+  justQuestion,
+  shuffledAnswers
+}) => {
+  const [isHovered, setIsHovered] = useState(false)
 
   return (
     <div>
@@ -11,7 +19,7 @@ export const QuizSelectionPage = ({selectedAnswer, timeCount, quizData, justQues
         style={{
           fontSize: "30px",
           fontWeight: "bold",
-          color: timeCount <= 2 ? "red" : "orange",
+          color: timeCount <= 2 ? "red" : "orange"
         }}
       >
         {timeCount} 秒以内に
@@ -25,15 +33,29 @@ export const QuizSelectionPage = ({selectedAnswer, timeCount, quizData, justQues
           style={{ width: "auto", height: "250px" }}
         />
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "15px", width: "230px", margin: "0 auto" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "15px",
+          width: "230px",
+          margin: "0 auto"
+        }}
+      >
         {shuffledAnswers.map((answer, index) => (
           <button
             key={index}
             onClick={() => selectedAnswer(answer)}
             style={{
               ...globalButtonStyle,
-              backgroundColor: isHovered === index ? globalButtonHoverStyle.backgroundColor : "#00BBFF",
-              boxShadow: isHovered === index ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
+              backgroundColor:
+                isHovered === index
+                  ? globalButtonHoverStyle.backgroundColor
+                  : "#00BBFF",
+              boxShadow:
+                isHovered === index
+                  ? globalButtonHoverStyle.boxShadow
+                  : globalButtonStyle.boxShadow
             }}
             onMouseOver={() => setIsHovered(index)}
             onMouseOut={() => setIsHovered(null)}

--- a/src/components/TopPage.jsx
+++ b/src/components/TopPage.jsx
@@ -1,20 +1,34 @@
-import { useState } from 'react';
-import { globalButtonStyle, globalButtonHoverStyle } from '../styles/globalButton';
+import { useState } from "react"
+import {
+  globalButtonStyle,
+  globalButtonHoverStyle
+} from "../styles/globalButton"
 
 export const TopPage = ({ handleClick }) => {
-  const [isHovered, setIsHovered] = useState(false);
+  const [isHovered, setIsHovered] = useState(false)
 
-  const buttonStyle = {   // このコンポーネントでのボタンのスタイルを指定
+  const buttonStyle = {
+    // このコンポーネントでのボタンのスタイルを指定
     ...globalButtonStyle,
-    backgroundColor: isHovered ? globalButtonHoverStyle.backgroundColor : "violet",
-    boxShadow: isHovered ? globalButtonHoverStyle.boxShadow : globalButtonStyle.boxShadow,
-  };
+    backgroundColor: isHovered
+      ? globalButtonHoverStyle.backgroundColor
+      : "violet",
+    boxShadow: isHovered
+      ? globalButtonHoverStyle.boxShadow
+      : globalButtonStyle.boxShadow
+  }
 
   return (
     <div>
-      <h3 style={{ color: "orange", marginBottom: "20px" }}>全人類の基本をクリアせよ！</h3>
+      <h3 style={{ color: "orange", marginBottom: "20px" }}>
+        全人類の基本をクリアせよ！
+      </h3>
       <div style={{ marginBottom: "30px" }}>
-        <img src="/images/ご挨拶.png" alt="スタート画面" style={{ width: "auto", height: "250px" }} />
+        <img
+          src="/images/ご挨拶.png"
+          alt="スタート画面"
+          style={{ width: "auto", height: "250px" }}
+        />
       </div>
       <button
         onClick={handleClick}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import React from "react"
+import ReactDOM from "react-dom/client"
+import App from "./App"
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"))
 root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-);
+)

--- a/src/styles/globalButton.jsx
+++ b/src/styles/globalButton.jsx
@@ -5,10 +5,10 @@ export const globalButtonStyle = {
   color: "white",
   fontSize: "20px",
   cursor: "pointer",
-  boxShadow: "0 4px 8px rgb(250, 150, 0, 0.6)",
-};
+  boxShadow: "0 4px 8px rgb(250, 150, 0, 0.6)"
+}
 
 export const globalButtonHoverStyle = {
   backgroundColor: "orange",
-  boxShadow: "none",
-};
+  boxShadow: "none"
+}

--- a/src/styles/xShareButton.jsx
+++ b/src/styles/xShareButton.jsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import { TwitterShareButton } from 'react-share';
+import { useState } from "react"
+import { TwitterShareButton } from "react-share"
 
 export const XShareButton = ({ quizData, score }) => {
-  const shareText = `\n \n ${quizData.length}人中、${score}人に好かれた🧡\n #高速ご挨拶クイズ\n `;
-  const [isHovered, setIsHovered] = useState(false);
+  const shareText = `\n \n ${quizData.length}人中、${score}人に好かれた🧡\n #高速ご挨拶クイズ\n `
+  const [isHovered, setIsHovered] = useState(false)
 
   return (
     <TwitterShareButton
@@ -13,24 +13,24 @@ export const XShareButton = ({ quizData, score }) => {
         marginTop: "30px",
         cursor: "pointer",
         boxShadow: isHovered ? "none" : "0 4px 8px rgb(250, 150, 0, 0.6)",
-        borderRadius: '10px',
-        backgroundColor: isHovered ? 'yellow' : '#a7ffff', //シアン
-        padding: '5px',
-        display: 'inline-flex',
-        justifyContent: 'center',
-        alignItems: 'center',
+        borderRadius: "10px",
+        backgroundColor: isHovered ? "yellow" : "#a7ffff", //シアン
+        padding: "5px",
+        display: "inline-flex",
+        justifyContent: "center",
+        alignItems: "center"
       }}
       onMouseOver={() => setIsHovered(true)} // Hover stateをtrueに
       onMouseOut={() => setIsHovered(false)} // Hover stateをfalseに
       target="_blank"
     >
       <img
-        src={isHovered ? '/images/xshare-hover.svg' : '/images/xshare.svg'}
+        src={isHovered ? "/images/xshare-hover.svg" : "/images/xshare.svg"}
         style={{
-          width: '60px',
-          height: '60px',
+          width: "60px",
+          height: "60px"
         }}
       />
     </TwitterShareButton>
-  );
+  )
 }


### PR DESCRIPTION
# Prettierを導入し、コマンドでフォーマットを実行できるようにする
**できるようになったこと**
- 以下のコマンドでフォーマットを実行できるようにした
  ```bash
  npm run format
  ```
**実装**（参考記事：[Prettier(パッケージ版)の導入,`.prettierrc`(ルール設定) / `.prettierignore`(無視設定)](https://qiita.com/kkrtech/items/6416517f04347b980f8e)）
- `package.json`・`package-lock.json`に追加
  - Prettierをインストール（[Prettier公式](https://prettier.io/docs/install)）
  - フォーマットを実行するコマンドを指定
- `.prettierignore`を生成
  - `.github/PULL_REQUEST_TEMPLATE.md` `README.md`をフォーマット実行する範囲から除外
- `.prettierrc`を生成
  - フォーマットを実行する内容を記載